### PR TITLE
Refactor API for better UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ const bus = system();
 	const state = await unit.activeState;
 	
 	console.log('Unit openvpn.service state is', state);
+
+    // Start the service.
+    await unit.start();
+
+    console.log('Unit openvpn.service state is now', await unit.activeState);
 })();
 ```
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,26 +2,15 @@ version: '2.3'
 services:
   # This provides the testing systemd interface
   mock-systemd:
-    image: ghcr.io/balena-os/mock-systemd-bus:0.1.1
-    depends_on:
-       - dbus
+    image: ghcr.io/balena-os/mock-systemd-bus:0.2.0
+    privileged: true
     volumes:
-      - dbus:/run/dbus
+      - dbus:/shared/dbus
     environment:
       # Set this variable with the location of your bus socket
-      # DO NOT try to use your actual system bus
-      DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
+      DBUS_SYSTEM_BUS_ADDRESS: unix:path=/shared/dbus/system_bus_socket
       # Optionally set-up any fake units you need
       MOCK_SYSTEMD_UNITS: openvpn.service dummy.service
-
-  # This provides the bus
-  dbus:
-    image: balenablocks/dbus
-    environment:
-      DBUS_CONFIG: session.conf
-      DBUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
-    volumes:
-      - dbus:/run/dbus
 
   sut:
     build: ./
@@ -35,12 +24,11 @@ services:
       ]
     stop_grace_period: 3s
     environment:
-      DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
+      DBUS_SYSTEM_BUS_ADDRESS: unix:path=/shared/dbus/system_bus_socket
     depends_on:
-      - dbus
       - mock-systemd
     volumes:
-      - dbus:/run/dbus
+      - dbus:/shared/dbus
 
 volumes:
   dbus:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,53 +2,118 @@ import {
 	SystemBus,
 	unitActiveState,
 	unitPartOf,
-	startUnit,
-	stopUnit,
-	restartUnit,
+	unitStart,
+	unitStop,
+	unitRestart,
 	powerOff,
 	reboot,
 } from '../index.node';
 
 export { system } from '../index.node';
+
+/**
+ * See: https://www.freedesktop.org/wiki/Software/systemd/dbus/
+ */
 export class ServiceManager {
-	constructor(readonly bus: SystemBus) { }
+	constructor(readonly bus: SystemBus) {}
 
 	getUnit(name: string) {
 		return new Unit(this.bus, name);
 	}
-
-	async startUnit(name: string, mode: string): Promise<void> {
-		await startUnit.call(this.bus, name, mode);
-	}
-
-	async stopUnit(name: string, mode: string): Promise<void> {
-		await stopUnit.call(this.bus, name, mode);
-	}
-
-	async restartUnit(name: string, mode: string): Promise<void> {
-		await restartUnit.call(this.bus, name, mode);
-	}
 }
+
+/**
+ * Systemd Job mode
+ *
+ * From: https://www.freedesktop.org/wiki/Software/systemd/dbus/
+ *
+ * > The mode needs to be one of replace, fail, isolate, ignore-dependencies, ignore-requirements. If "replace" the call will start the unit and its dependencies, possibly replacing already queued jobs that conflict with this. If "fail" the call will start the unit and its dependencies, but will fail if this would change an already queued job. If "isolate" the call will start the unit in question and terminate all units that aren't dependencies of it. If "ignore-dependencies" it will start a unit but ignore all its dependencies. If "ignore-requirements" it will start a unit but only ignore the requirement dependencies. It is not recommended to make use of the latter two options. Returns the newly created job object.
+ */
+export type JobMode = 'replace' | 'fail' | 'isolate' | 'ignore-dependencies';
 
 export class Unit {
-	constructor(readonly bus: SystemBus, readonly name: string) { }
+	constructor(readonly bus: SystemBus, readonly name: string) {}
 
+	/**
+	 * Return the unit state
+	 *
+	 * From: https://www.freedesktop.org/wiki/Software/systemd/dbus/
+	 *
+	 * > ActiveState contains a state value that reflects whether the unit is currently active or not. The following states are currently defined: active, reloading, inactive, failed, activating, deactivating. active indicates that unit is active (obviously...). reloading indicates that the unit is active and currently reloading its configuration. inactive indicates that it is inactive and the previous run was successful or no previous run has taken place yet. failed indicates that it is inactive and the previous run was not successful (more information about the reason for this is available on the unit type specific interfaces, for example for services in the Result property, see below). activating indicates that the unit has previously been inactive but is currently in the process of entering an active state. Conversely deactivating indicates that the unit is currently in the process of deactivation.
+	 */
 	get activeState(): Promise<string> {
-		return unitActiveState.call(this.bus, this.name);
+		return unitActiveState(this.bus, this.name);
 	}
+
+	/**
+	 * Return the list of units this unit is part of, i.e. the units that when restarted
+	 * will also trigger a restart of `this` unit.
+	 *
+	 * https://www.freedesktop.org/software/systemd/man/systemd.unit.html#PartOf=
+	 */
 	get partOf(): Promise<string[]> {
-		return unitPartOf.call(this.bus, this.name);
+		return unitPartOf(this.bus, this.name);
+	}
+
+	/**
+	 * Enqueues a start job and possibly dependent jobs.
+	 *
+	 *
+	 * From: https://www.freedesktop.org/wiki/Software/systemd/dbus/
+	 *
+	 * > The mode needs to be one of replace, fail, isolate, ignore-dependencies, ignore-requirements. If "replace" the call will start the unit and its dependencies, possibly replacing already queued jobs that conflict with this. If "fail" the call will start the unit and its dependencies, but will fail if this would change an already queued job. If "isolate" the call will start the unit in question and terminate all units that aren't dependencies of it. If "ignore-dependencies" it will start a unit but ignore all its dependencies. If "ignore-requirements" it will start a unit but only ignore the requirement dependencies. It is not recommended to make use of the latter two options. Returns the newly created job object.
+	 */
+	async start(mode: JobMode = 'fail'): Promise<void> {
+		await unitStart(this.bus, this.name, mode);
+	}
+
+	/**
+	 * Enqueues a stop job and possibly dependent jobs.
+	 *
+	 * This defaults to `fail` mode
+	 *
+	 * @see: https://www.freedesktop.org/wiki/Software/systemd/dbus/
+	 * @see Unit.star
+	 */
+	async stop(mode: JobMode = 'fail'): Promise<void> {
+		await unitStop(this.bus, this.name, mode);
+	}
+
+	/**
+	 * Enqueues a stop job and possibly dependent jobs.
+	 *
+	 * This defaults to `fail` mode
+	 *
+	 * See: https://www.freedesktop.org/wiki/Software/systemd/dbus/
+	 */
+	async restart(mode: JobMode = 'fail'): Promise<void> {
+		await unitRestart(this.bus, this.name, mode);
 	}
 }
 
+/**
+ * See https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html
+ */
 export class LoginManager {
-	constructor(readonly bus: SystemBus) { }
+	constructor(readonly bus: SystemBus) {}
 
+	/**
+	 * Reboot the system.
+	 *
+	 * This defaults to not asking for user confirmation.
+	 *
+	 * From: https://www.freedesktop.org/wiki/Software/systemd/dbus/
+	 */
 	async reboot(interactive = false): Promise<void> {
-		await reboot.call(this.bus, interactive);
+		await reboot(this.bus, interactive);
 	}
 
+	/**
+	 * Power off the system
+	 *
+	 * This defaults to not asking for user confirmation.
+	 */
 	async powerOff(interactive = false): Promise<void> {
-		await powerOff.call(this.bus, interactive);
+		await powerOff(this.bus, interactive);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Essential systemd D-Bus bindings for Node.js",
   "homepage": "https://github.com/balena-io-modules/systemd#readme",
   "main": "build/index.js",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/balena-io-modules/systemd.git"

--- a/tests/service-manager.spec.ts
+++ b/tests/service-manager.spec.ts
@@ -23,11 +23,11 @@ describe('ServiceManager', () => {
 			).to.not.be.rejected;
 		});
 
-		it('activeState starts as "inactive"', async () => {
+		it('activeState starts as "active"', async () => {
 			const manager = new ServiceManager(bus);
 			await expect(
 				manager.getUnit('dummy.service').activeState,
-			).to.eventually.equal('inactive');
+			).to.eventually.equal('active');
 		});
 
 		it('partOf can be queried', async () => {
@@ -40,43 +40,28 @@ describe('ServiceManager', () => {
 
 	describe('ServiceManager', () => {
 		it('allows to start unit', async () => {
-			const manager = new ServiceManager(bus);
+			const unit = new ServiceManager(bus).getUnit('dummy.service');
 
-			await expect(manager.startUnit('dummy.service', 'fail')).to.not.be
-				.rejected;
-			await expect(
-				manager.getUnit('dummy.service').activeState,
-			).to.eventually.equal('active');
+			await expect(unit.start('fail')).to.not.be.rejected;
+			await expect(unit.activeState).to.eventually.equal('active');
 		});
 
 		it('allows to stop unit', async () => {
-			const manager = new ServiceManager(bus);
+			const unit = new ServiceManager(bus).getUnit('dummy.service');
 
-			await expect(manager.stopUnit('dummy.service', 'fail')).to.not.be
-				.rejected;
-			await expect(
-				manager.getUnit('dummy.service').activeState,
-			).to.eventually.equal('inactive');
+			await expect(unit.stop('fail')).to.not.be.rejected;
+			await expect(unit.activeState).to.eventually.equal('inactive');
 		});
 
 		it('allows to restart unit', async () => {
-			const manager = new ServiceManager(bus);
+			const unit = new ServiceManager(bus).getUnit('dummy.service');
 
-			await expect(manager.restartUnit('dummy.service', 'fail')).to.not.be
-				.rejected;
-			await expect(
-				manager.getUnit('dummy.service').activeState,
-			).to.eventually.equal('active');
-			await expect(manager.stopUnit('dummy.service', 'fail')).to.not.be
-				.rejected;
-			await expect(
-				manager.getUnit('dummy.service').activeState,
-			).to.eventually.equal('inactive');
-			await expect(manager.restartUnit('dummy.service', 'fail')).to.not.be
-				.rejected;
-			await expect(
-				manager.getUnit('dummy.service').activeState,
-			).to.eventually.equal('active');
+			await expect(unit.restart('fail')).to.not.be.rejected;
+			await expect(unit.activeState).to.eventually.equal('active');
+			await expect(unit.stop('fail')).to.not.be.rejected;
+			await expect(unit.activeState).to.eventually.equal('inactive');
+			await expect(unit.restart('fail')).to.not.be.rejected;
+			await expect(unit.activeState).to.eventually.equal('active');
 		});
 	});
 });

--- a/typings/index.node.d.ts
+++ b/typings/index.node.d.ts
@@ -4,11 +4,11 @@ declare module "*index.node" {
 	function system(): SystemBus;
 
 	// These methods
-	function unitActiveState(unitName: string): Promise<string>;
-	function unitPartOf(unitName: string): Promise<string[]>;
-	function startUnit(unitName: string, mode: string): Promise<void>;
-	function stopUnit(unitName: string, mode: string): Promise<void>;
-	function restartUnit(unitName: string, mode: string): Promise<void>;
-	function reboot(interactive: boolean): Promise<void>;
-	function powerOff(interactive: boolean): Promise<void>;
+	function unitActiveState(bus: SystemBus, unitName: string): Promise<string>;
+	function unitPartOf(bus: SystemBus, unitName: string): Promise<string[]>;
+	function unitStart(bus: SystemBus, unitName: string, mode: string): Promise<void>;
+	function unitStop(bus: SystemBus, unitName: string, mode: string): Promise<void>;
+	function unitRestart(bus: SystemBus, unitName: string, mode: string): Promise<void>;
+	function reboot(bus: SystemBus, interactive: boolean): Promise<void>;
+	function powerOff(bus: SystemBus, interactive: boolean): Promise<void>;
 }


### PR DESCRIPTION
This PR moves the unit control methods to the unit object. Even if they belong to the manager object in the systemd specification, they make more sense under the unit object, providing better UX.

This also refactors the methods exposed by the rust bindings, for better code readability.

Change-type: minor
