### PR TITLE
Make `system()` constructor an async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ This project was bootstrapped by [create-neon](https://www.npmjs.com/package/cre
 ```
 import {ServiceManager, system} from '@balena/systemd';
 
-// This runs synchronously but the connection is shared between
-// all methods. It will throw if the bus is not available
-const bus = system();
-
 (async() {
+	// This returns a new connection to the bus
+	// use singleton() if want to share a connection across
+    // your code
+	const bus = await system();
 	const manager = new ServiceManager(bus);
 	const unit = manager.getUnit('openvpn.service');
 
@@ -62,11 +62,10 @@ const bus = system();
 ```
 import {LoginManager, system} from '@balena/systemd';
 
-// This runs synchronously but the connection is shared between
-// all methods. It will throw if the bus is not available
-const bus = system();
-
 (async() {
+	// This returns a new connection to the bus
+	// use singleton() if want to share a connection across
+	const bus = await system();
 	const manager = new LoginManager(bus);
 
 	// WARNING: this WILL reboot the system!

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,9 +7,26 @@ import {
 	unitRestart,
 	powerOff,
 	reboot,
+	system,
 } from '../index.node';
 
-export { system } from '../index.node';
+export { system, SystemBus } from '../index.node';
+
+/**
+ * Convenience method to return a singleton instance of the system bus.
+ *
+ * Use this instead of system() if you want to avoid creating
+ * multiple connections
+ */
+export const singleton = (() => {
+	let bus: SystemBus | null = null;
+	return async function () {
+		if (!bus) {
+			bus = await system();
+		}
+		return bus;
+	};
+})();
 
 /**
  * See: https://www.freedesktop.org/wiki/Software/systemd/dbus/

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "balena-lint --typescript lib tests",
     "lint-fix": "balena-lint --typescript --fix lib tests",
     "build": "npm run build:rust && npm run build:node",
-    "build:node": "npm run clean && tsc",
+    "build:node": "npm run clean && tsc --project tsconfig.release.json",
     "build:rust": "RUSTFLAGS='-C target-feature=-crt-static' npx cargo-cp-artifact -ac balena-systemd index.node -- cargo build --message-format=json-render-diagnostics",
     "build:rust:debug": "npm run build:rust --",
     "build:rust:release": "npm run build:rust -- --release",

--- a/tests/login-manager.spec.ts
+++ b/tests/login-manager.spec.ts
@@ -5,8 +5,6 @@ import { exec as execSync } from 'child_process';
 
 const exec = promisify(execSync);
 
-const bus = system();
-
 export async function dbusSend(
 	dest: string,
 	path: string,
@@ -40,6 +38,7 @@ export async function dbusSend(
 
 describe('LoginManager', () => {
 	it('allows to reboot the system', async () => {
+		const bus = await system();
 		const manager = new LoginManager(bus);
 		await expect(manager.reboot()).to.not.be.rejected;
 
@@ -57,6 +56,7 @@ describe('LoginManager', () => {
 	});
 
 	it('allows to power off the system', async () => {
+		const bus = await system();
 		const manager = new LoginManager(bus);
 		await expect(manager.powerOff()).to.not.be.rejected;
 

--- a/tests/service-manager.spec.ts
+++ b/tests/service-manager.spec.ts
@@ -1,17 +1,17 @@
 import { expect } from './chai';
-import { system, ServiceManager } from '../lib';
-
-const bus = system();
+import { singleton, ServiceManager } from '../lib';
 
 describe('ServiceManager', () => {
 	describe('Unit', () => {
 		it('activeState can be queried', async () => {
+			const bus = await singleton();
 			const manager = new ServiceManager(bus);
 			await expect(manager.getUnit('dummy.service').activeState).to.not.be
 				.rejected;
 		});
 
 		it('activeState can be queried in parallel', async () => {
+			const bus = await singleton();
 			const manager = new ServiceManager(bus);
 			// TODO: how can we test that the call is indeed not blocking the
 			// main thread?
@@ -24,6 +24,7 @@ describe('ServiceManager', () => {
 		});
 
 		it('activeState starts as "active"', async () => {
+			const bus = await singleton();
 			const manager = new ServiceManager(bus);
 			await expect(
 				manager.getUnit('dummy.service').activeState,
@@ -31,6 +32,7 @@ describe('ServiceManager', () => {
 		});
 
 		it('partOf can be queried', async () => {
+			const bus = await singleton();
 			const manager = new ServiceManager(bus);
 			await expect(
 				manager.getUnit('dummy.service').partOf,
@@ -40,6 +42,7 @@ describe('ServiceManager', () => {
 
 	describe('ServiceManager', () => {
 		it('allows to start unit', async () => {
+			const bus = await singleton();
 			const unit = new ServiceManager(bus).getUnit('dummy.service');
 
 			await expect(unit.start('fail')).to.not.be.rejected;
@@ -47,6 +50,7 @@ describe('ServiceManager', () => {
 		});
 
 		it('allows to stop unit', async () => {
+			const bus = await singleton();
 			const unit = new ServiceManager(bus).getUnit('dummy.service');
 
 			await expect(unit.stop('fail')).to.not.be.rejected;
@@ -54,6 +58,7 @@ describe('ServiceManager', () => {
 		});
 
 		it('allows to restart unit', async () => {
+			const bus = await singleton();
 			const unit = new ServiceManager(bus).getUnit('dummy.service');
 
 			await expect(unit.restart('fail')).to.not.be.rejected;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 	},
 	"include": [
 		"lib/**/*.ts",
+		"tests/**/*.ts",
 		"typings/**/*.d.ts"
 	]
 }

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "lib/**/*.ts",
+    "typings/**/*.d.ts"
+  ],
+  "exclude": [
+    "lib/**/*.spec.ts"
+  ]
+}

--- a/typings/index.node.d.ts
+++ b/typings/index.node.d.ts
@@ -1,7 +1,14 @@
 declare module "*index.node" {
-	type SystemBus = {};
+	class SystemBus {
+		// Needed for typechecking
+		private __id: unique symbol
 
-	function system(): SystemBus;
+		// Do not allow direct instantiation
+		// or sub-classing
+		private constructor();
+	};
+
+	function system(): Promise<SystemBus>;
 
 	// These methods
 	function unitActiveState(bus: SystemBus, unitName: string): Promise<string>;


### PR DESCRIPTION
Before it was synchronous, relying on opening a connection being a cheap operation, but this is really an anti-pattern as any I/O operation really needs to happen outside the main loop.

This also improves the types to allow better type checking by the typescript compiler.

Change-type: minor